### PR TITLE
BUG: remote base path is added twice when rsyncning index

### DIFF
--- a/bamboost/core/remote.py
+++ b/bamboost/core/remote.py
@@ -238,7 +238,7 @@ class Remote(Index):
 
         else:
             stream_popen_output(self._fetch_remote_database)(
-               str(constants.DEFAULT_DATABASE_NAME)
+               str(constants.DEFAULT_DATABASE_FILE_NAME)
             )
 
     def rsync(self, source: StrPath, dest: StrPath) -> subprocess.Popen:


### PR DESCRIPTION
    Alternatively, I could remove it from here instead, let me know what is the best solution : 
    
    DATABASE_REMOTE_PATH = Path(_config._LOCAL_DIR).joinpath(
        constants.DEFAULT_DATABASE_FILE_NAME
    )