### PR TITLE
fix(collection): ensure exact parameter matching for duplicate check

### DIFF
--- a/bamboost/core/collection.py
+++ b/bamboost/core/collection.py
@@ -700,8 +700,11 @@ class Collection(ElligibleForPlugin):
         else:
             raise ArgumentError("name must be a string or an iterable of strings.")
 
-        # Check that all names exist in the collection
-        existing_names = set(self.all_simulation_names())
+        # Check that all names exist in the collection (even if filtered)
+        unfiltered_record = self._index.collection(self.uid)
+        if unfiltered_record is None:
+            raise RuntimeError(f"Collection {self.uid} not found in index.")
+        existing_names = {sim.name for sim in unfiltered_record.simulations}
         for n in names:
             if n not in existing_names:
                 raise ValueError(f"Simulation {n} does not exist in the collection.")
@@ -761,7 +764,11 @@ class Collection(ElligibleForPlugin):
         return matches
 
     def _list_duplicates(
-        self, parameters: Mapping, *, df: pd.DataFrame | None = None
+        self,
+        parameters: Mapping,
+        *,
+        df: pd.DataFrame | None = None,
+        exact: bool = False,
     ) -> list[str]:
         """List the names (IDs) of simulations in the collection that have duplicate
         parameter values.
@@ -771,6 +778,9 @@ class Collection(ElligibleForPlugin):
                 names, values are the values to match against existing simulations.
             df: DataFrame to search in. If not provided, the DataFrame from the SQL
                 database is used.
+            exact: If True, only matches simulations that have exactly the same set of
+                parameters. If False (default), matches simulations that have at least
+                the provided parameters matching.
 
         Returns:
             list[str]: List of simulation names (IDs) that have the same parameter values
@@ -787,6 +797,8 @@ class Collection(ElligibleForPlugin):
                 self.ori = np.asarray(ori)
 
             def __eq__(self, other):
+                if hasattr(other, "ori"):
+                    other = other.ori
                 return np.array_equal(np.asarray(other), self.ori)
 
         # make all iterables comparable by converting them to ComparableIterable
@@ -796,13 +808,34 @@ class Collection(ElligibleForPlugin):
 
         # if any of the parameters is not in the dataframe, no duplicates
         for p in params:
-            if p not in df.keys():
+            if p not in df.columns:
                 return []
 
         # get matching rows where all values of the series are equal to the corresponding values in the dataframe
         s = pd.Series(params)
-        match = df.loc[(df[s.keys()].apply(lambda row: (s == row).all(), axis=1))]
-        return match.name.tolist()
+        if s.empty:
+            mask = pd.Series(True, index=df.index)
+        else:
+            # Vectorized comparison (handles ComparableIterable via __eq__ and object-dtype columns)
+            mask = (df[s.keys()] == s).all(axis=1)
+
+        if exact:
+            # For exact match, all other parameter columns must be NaN/missing
+            metadata_cols = {
+                "name",
+                "created_at",
+                "description",
+                "tags",
+                "status",
+                "submitted",
+            }
+            other_param_cols = [
+                c for c in df.columns if c not in s.keys() and c not in metadata_cols
+            ]
+            for col in other_param_cols:
+                mask &= df[col].isna()
+
+        return df.loc[mask].name.tolist()
 
     def _check_duplicate(self, parameters: Mapping) -> Literal[True]:
         """Check whether the given parameters dictionary already exists in the collection.
@@ -812,8 +845,19 @@ class Collection(ElligibleForPlugin):
         Args:
             parameters (dict): Parameter dictionary to check for duplicates.
         """
+        # we must check for duplicates in the WHOLE collection, not just the filtered view
+        unfiltered_record = self._index.collection(self.uid)
+        if unfiltered_record is None:
+            raise RuntimeError("Collection not found in index.")
 
-        duplicates = self._list_duplicates(parameters)
+        # resolve linked parameters if necessary (to match the behavior of df)
+        if self._include_links:
+            unfiltered_record = self._index.insert_linked_sim_parameters(
+                unfiltered_record, self._include_links
+            )
+
+        df = unfiltered_record.to_pandas()
+        duplicates = self._list_duplicates(parameters, df=df, exact=True)
         if len(duplicates) == 0:
             return True
 

--- a/bamboost/core/collection.py
+++ b/bamboost/core/collection.py
@@ -386,7 +386,9 @@ class Collection(ElligibleForPlugin):
 
         return self._replace(_include_links=keys)
 
-    def to_pandas(self, flatten: bool = True) -> pd.DataFrame:
+    def to_pandas(
+        self, flatten: bool = True, include_links: bool = True
+    ) -> pd.DataFrame:
         """Returns a pandas DataFrame representing the collection and its parameter space.
 
         The DataFrame contains all simulations in the collection, including their
@@ -399,11 +401,13 @@ class Collection(ElligibleForPlugin):
         Args:
             flatten: If True (default), flatten nested parameter dictionaries into a single
                 level using dot notation. If False, keep nested dictionaries as they are.
+            include_links: If True (default), the link (name and target) are included as
+                columns.
 
         Returns:
-            pd.DataFrame: DataFrame of the collection's simulations and parameters.
+            DataFrame of the collection's simulations and parameters.
         """
-        df = self._record.to_pandas(flatten=flatten)
+        df = self._record.to_pandas(flatten=flatten, include_links=include_links)
 
         # apply filtering if necessary
         if self._filter is not None:

--- a/bamboost/core/collection.py
+++ b/bamboost/core/collection.py
@@ -43,6 +43,7 @@ from bamboost._config import config
 from bamboost._logger import BAMBOOST_LOGGER
 from bamboost._typing import StrPath
 from bamboost.core.simulation.base import Simulation, SimulationWriter
+from bamboost.core.simulation.dict import validate_parameter_key
 from bamboost.core.utilities import dedupe_str_iter, flatten_dict
 from bamboost.exceptions import DuplicateSimulationError, InvalidCollectionError
 from bamboost.index import (
@@ -588,6 +589,11 @@ class Collection(ElligibleForPlugin):
 
         name = SimulationName(name)  # Generates a unique id as name if not provided
         directory = self.path.joinpath(name)
+
+        # Validate parameters keys (top-level only)
+        if parameters:
+            for key in parameters:
+                validate_parameter_key(key)
 
         # Check if name is already in use, otherwise create a new directory
         if self._comm.rank == 0:

--- a/bamboost/core/collection.py
+++ b/bamboost/core/collection.py
@@ -609,10 +609,10 @@ class Collection(ElligibleForPlugin):
 
         # Root process creates the directory if it does not exist
         if self._comm.rank == 0:
-            # Check for duplicate parameters if provided
-            if parameters and duplicate_action != "ignore" and not override:
+            # Check for duplicate parameters/links if provided
+            if (parameters or links) and duplicate_action != "ignore" and not override:
                 try:
-                    self._check_duplicate(parameters)
+                    self._check_duplicate(parameters, links=links)
                 except DuplicateSimulationError as e:
                     if duplicate_action == "raise":
                         raise
@@ -765,8 +765,9 @@ class Collection(ElligibleForPlugin):
 
     def _list_duplicates(
         self,
-        parameters: Mapping,
+        parameters: Mapping | None = None,
         *,
+        links: Mapping | None = None,
         df: pd.DataFrame | None = None,
         exact: bool = False,
     ) -> list[str]:
@@ -776,6 +777,7 @@ class Collection(ElligibleForPlugin):
         Args:
             parameters: Parameter dictionary to check for duplicates. Keys are parameter
                 names, values are the values to match against existing simulations.
+            links: Dictionary of simulation links to include in the duplicate check.
             df: DataFrame to search in. If not provided, the DataFrame from the SQL
                 database is used.
             exact: If True, only matches simulations that have exactly the same set of
@@ -789,8 +791,11 @@ class Collection(ElligibleForPlugin):
         import pandas as pd
 
         if df is None:
-            df = self._record.to_pandas()
-        params = flatten_dict(parameters)
+            df = self._record.to_pandas(include_links=True)
+        params = flatten_dict(parameters or {})
+        if links:
+            # Prefix links to match flattened DataFrame columns
+            params.update(flatten_dict({"links": links}))
 
         class ComparableIterable:
             def __init__(self, ori):
@@ -806,7 +811,7 @@ class Collection(ElligibleForPlugin):
             if isinstance(params[k], Iterable) and not isinstance(params[k], str):
                 params[k] = ComparableIterable(params[k])
 
-        # if any of the parameters is not in the dataframe, no duplicates
+        # if any of the parameters/links is not in the dataframe, no duplicates
         for p in params:
             if p not in df.columns:
                 return []
@@ -820,7 +825,8 @@ class Collection(ElligibleForPlugin):
             mask = (df[s.keys()] == s).all(axis=1)
 
         if exact:
-            # For exact match, all other parameter columns must be NaN/missing
+            # For exact match, all other parameter/link columns must be NaN/missing.
+            # We exclude tags, description, and other internal metadata.
             metadata_cols = {
                 "name",
                 "created_at",
@@ -829,21 +835,24 @@ class Collection(ElligibleForPlugin):
                 "status",
                 "submitted",
             }
-            other_param_cols = [
+            other_cols = [
                 c for c in df.columns if c not in s.keys() and c not in metadata_cols
             ]
-            for col in other_param_cols:
+            for col in other_cols:
                 mask &= df[col].isna()
 
         return df.loc[mask].name.tolist()
 
-    def _check_duplicate(self, parameters: Mapping) -> Literal[True]:
+    def _check_duplicate(
+        self, parameters: Mapping | None = None, *, links: Mapping | None = None
+    ) -> Literal[True]:
         """Check whether the given parameters dictionary already exists in the collection.
         Returns True if no duplicates are found. Raises `DuplicateSimulationError` if
         duplicates are found.
 
         Args:
             parameters (dict): Parameter dictionary to check for duplicates.
+            links (dict): Links dictionary to check for duplicates.
         """
         # we must check for duplicates in the WHOLE collection, not just the filtered view
         unfiltered_record = self._index.collection(self.uid)
@@ -856,8 +865,8 @@ class Collection(ElligibleForPlugin):
                 unfiltered_record, self._include_links
             )
 
-        df = unfiltered_record.to_pandas()
-        duplicates = self._list_duplicates(parameters, df=df, exact=True)
+        df = unfiltered_record.to_pandas(include_links=True)
+        duplicates = self._list_duplicates(parameters, links=links, df=df, exact=True)
         if len(duplicates) == 0:
             return True
 

--- a/bamboost/core/simulation/dict.py
+++ b/bamboost/core/simulation/dict.py
@@ -10,10 +10,46 @@ from bamboost import constants
 from bamboost.core import utilities
 from bamboost.core.hdf5.attrsdict import AttrsDict, AttrsEncoder, mutable_only
 from bamboost.core.hdf5.file import _MT, FileMode, Mutable, with_file_open
+from bamboost.exceptions import ForbiddenParameterKeyError
 from bamboost.index import SimulationUID
 
 if TYPE_CHECKING:
     from bamboost.core.simulation.base import _Simulation
+
+
+RESERVED_KEYS = {
+    "id",
+    "collection_uid",
+    "name",
+    "created_at",
+    "modified_at",
+    "description",
+    "tags",
+    "status",
+    "submitted",
+    "links",
+}
+
+
+def validate_parameter_key(key: str) -> None:
+    """Validate a parameter key.
+
+    Args:
+        key: The key to validate.
+
+    Raises:
+        ValueError: If the key is reserved or contains a period.
+    """
+    # only top-level keys are checked for reservation and periods.
+    # nested keys (e.g., 'params.nested_key') are already handled by the flattening logic
+    # but we want to prevent users from manually passing a key with a period
+    # which would interfere with our flattening/unflattening.
+    if key in RESERVED_KEYS:
+        raise ForbiddenParameterKeyError(f"Parameter key '{key}' is reserved.")
+    if "." in key:
+        raise ForbiddenParameterKeyError(
+            f"Parameter key '{key}' cannot contain a period ('.')."
+        )
 
 
 class Parameters(AttrsDict[_MT]):
@@ -69,6 +105,7 @@ class Parameters(AttrsDict[_MT]):
 
     @mutable_only
     def __setitem__(self: Parameters[Mutable], key: str, value: Any) -> None:
+        validate_parameter_key(key)
         active_dict = reduce(lambda obj, k: obj[k], key.split(".")[:-1], self._dict)
         active_dict[key.split(".")[-1]] = value
 
@@ -103,6 +140,10 @@ class Parameters(AttrsDict[_MT]):
         Args:
             update_dict: new parameters
         """
+        # validate only top-level keys
+        for key in update_dict:
+            validate_parameter_key(key)
+
         # flatten dictionary
         flattened_dict = utilities.flatten_dict(update_dict)
 

--- a/bamboost/exceptions.py
+++ b/bamboost/exceptions.py
@@ -21,3 +21,15 @@ class InvalidSimulationUIDError(ValueError):
     """Raised when a simulation UID is invalid or does not exist."""
 
     pass
+
+
+class ForbiddenParameterKeyError(ValueError):
+    """Raised when a parameter key is reserved or contains a period."""
+
+    def __init__(self, key: str) -> None:
+        super().__init__()
+        self.key = key
+
+    def __str__(self) -> str:
+        base_message = super().__str__()
+        return f"{base_message} Invalid key: '{self.key}'"

--- a/bamboost/index/base.py
+++ b/bamboost/index/base.py
@@ -279,7 +279,7 @@ class Index(metaclass=RootProcessMeta):
             under_search_paths = any(
                 path.is_relative_to(s_path) for s_path in self.search_paths
             )
-            
+
             if not validate_path(path, uid) or not under_search_paths:
                 log.info(
                     "Invalid collection path in cache: %s -> removing.",
@@ -380,7 +380,12 @@ class Index(metaclass=RootProcessMeta):
 
     @_sql_transaction
     def sync_collection(
-        self, uid: str, path: StrPath | None = None, *, force_all: bool = False
+        self,
+        uid: str,
+        path: StrPath | None = None,
+        *,
+        force_all: bool = False,
+        heal_links: bool = True,
     ) -> None:
         """Sync the table with the file system.
 
@@ -390,6 +395,8 @@ class Index(metaclass=RootProcessMeta):
         Args:
             uid: UID of the collection
             path (Optional): Path of the collection
+            force_all: If True, sync all simulations regardless of modification time.
+            heal_links: If True, attempt to heal stale links in the collection after sync.
         """
         log.info(f"Syncing collection {uid} with the file system.")
         path = Path(path or self.resolve_path(uid)).absolute()
@@ -426,6 +433,9 @@ class Index(metaclass=RootProcessMeta):
             self.upsert_simulation(
                 collection_uid=uid, simulation_name=name, collection_path=path
             )
+
+        if heal_links:
+            self.heal_stale_links(uid)
 
     @property
     @RootProcessMeta.bcast_result
@@ -517,7 +527,7 @@ class Index(metaclass=RootProcessMeta):
 
     @RootProcessMeta.bcast_result
     @_sql_transaction
-    def collection_links_map(self, uid: str) -> dict[str, dict[str, str]]:
+    def collection_links_map(self, uid: str) -> dict[str, dict[str, SimulationUID]]:
         """Return a mapping of simulation names to their links for a specific collection.
 
         Args:
@@ -624,7 +634,6 @@ class Index(metaclass=RootProcessMeta):
 
         self._s.execute(store.collections_upsert_stmt(record))
 
-    @_sql_transaction
     def upsert_simulation(
         self,
         collection_uid: str,
@@ -670,12 +679,14 @@ class Index(metaclass=RootProcessMeta):
             "collection_uid": collection_uid,
             "name": simulation_name,
             "modified_at": datetime.now(),
+            "links": {k: str(SimulationUID(v)) for k, v in links.items()}
+            if links
+            else None,
             **normalize_simulation_metadata(metadata or {}),
         }
 
-        sim_id = self._s.execute(
-            store.simulations_upsert_stmt(sim_payload)
-        ).scalar_one()
+        with self.sql_transaction() as s:
+            sim_id = s.execute(store.simulations_upsert_stmt(sim_payload)).scalar_one()
 
         if links:
             self.update_simulation_links(
@@ -691,7 +702,8 @@ class Index(metaclass=RootProcessMeta):
                 {"simulation_id": sim_id, "key": key, "value": value}
                 for key, value in parameters.items()
             ]
-            self._s.execute(store.parameters_upsert_stmt(parameter_payload))
+            with self.sql_transaction() as s:
+                s.execute(store.parameters_upsert_stmt(parameter_payload))
 
     @_sql_transaction
     def update_simulation_metadata(
@@ -716,6 +728,7 @@ class Index(metaclass=RootProcessMeta):
         links: Mapping[str, Any],
         *,
         raise_on_invalid_target: bool = config.index.strictLinksWhenSyncing,
+        scan_and_sync: bool = True,
     ) -> None:
         """Update the links of a simulation.
 
@@ -726,16 +739,12 @@ class Index(metaclass=RootProcessMeta):
             raise_on_invalid_target: If True, raise an error if any of the target
                 simulations do not exist in the index. If False, log a warning and skip
                 the invalid links.
+            scan_and_sync: If True, if a target simulation is not found in the index, scan
+                for collections and sync the target collection before trying again. This
+                can be helpful to find targets.
         """
         scanned: bool = False  # flag to avoid multiple scans in case of multiple links
         known_collection_uids: tuple[str, ...] = store.get_collection_uids(self._s)
-
-        sim_id = store.fetch_simulation_id(self._s, collection_uid, simulation_name)
-        if sim_id is None:
-            raise InvalidSimulationUIDError(
-                f"Simulation '{collection_uid}:{simulation_name}' does not exist in the index. "
-                "This happened because you are trying to update the links of a simulation that cannot be found."
-            )
 
         def _raise_or_log_invalid_target(target_uid: SimulationUID) -> None:
             if raise_on_invalid_target:
@@ -757,6 +766,10 @@ class Index(metaclass=RootProcessMeta):
             if target_sim_id is not None:
                 return target_sim_id
 
+            if not scan_and_sync:
+                _raise_or_log_invalid_target(target_uid)
+                return None
+
             log.debug(
                 f"Target simulation '{target_uid}' not found in cache. "
                 "Scanning for/syncing collections and trying again."
@@ -770,7 +783,7 @@ class Index(metaclass=RootProcessMeta):
                 _raise_or_log_invalid_target(target_uid)
                 return None
 
-            self.sync_collection(target_uid.collection_uid)
+            self.sync_collection(target_uid.collection_uid, heal_links=False)
             target_sim_id = store.fetch_simulation_id(
                 self._s, target_uid.collection_uid, target_uid.simulation_name
             )
@@ -780,6 +793,24 @@ class Index(metaclass=RootProcessMeta):
             _raise_or_log_invalid_target(target_uid)
             return None
 
+        sim_id = store.fetch_simulation_id(self._s, collection_uid, simulation_name)
+        if sim_id is None:
+            raise InvalidSimulationUIDError(
+                f"Simulation '{collection_uid}:{simulation_name}' does not exist in the index. "
+                "This happened because you are trying to update the links of a simulation that cannot be found."
+            )
+
+        # update the JSON column in the simulations table (Source of Truth)
+        # This ensures DataFrames and duplicate checks see all links.
+        from sqlalchemy import update
+
+        self._s.execute(
+            update(store.simulations_table)
+            .where(store.simulations_table.c.id == sim_id)
+            .values(links={k: str(SimulationUID(v)) for k, v in links.items()})
+        )
+
+        # update the relational table for resolved links
         link_payloads = []
 
         for ref_name, target_uid_or_string in links.items():
@@ -787,13 +818,15 @@ class Index(metaclass=RootProcessMeta):
             target_sim_id = _find_target(target_uid)
             if target_sim_id is None:
                 # if the target simulation can not be found, we skip storing the link in
-                # the database
+                # the relational table for now.
                 continue
 
             link_payloads.append(
                 {"source_id": sim_id, "target_id": target_sim_id, "name": ref_name}
             )
 
+        # Remove existing relational links for this source before re-populating
+        self._s.execute(store.delete_simulation_links_stmt(sim_id))
         if link_payloads:
             self._s.execute(store.simulation_links_upsert_stmt(link_payloads))
 
@@ -820,6 +853,65 @@ class Index(metaclass=RootProcessMeta):
             for key, value in parameters.items()
         ]
         self._s.execute(store.parameters_upsert_stmt(parameter_payload))
+
+    @_sql_transaction
+    def heal_stale_links(self, collection_uid: str | None = None) -> None:
+        """Heal stale links in the database by resolving target_uids in JSON to target_ids.
+
+        Args:
+            collection_uid (Optional): UID of the collection to heal. If None, heal all
+                collections.
+        """
+        from sqlalchemy import func
+
+        # find all simulations where (count of resolved links) < (count of links in JSON)
+        # This is a bit tricky in pure SQL for JSON, so we'll just fetch simulations that
+        # HAVE links and do the check.
+        stmt = select(
+            store.simulations_table.c.id,
+            store.simulations_table.c.collection_uid,
+            store.simulations_table.c.name,
+            store.simulations_table.c.links,
+        ).where(store.simulations_table.c.links.is_not(None))
+
+        if collection_uid:
+            stmt = stmt.where(
+                store.simulations_table.c.collection_uid == collection_uid
+            )
+
+        sims = self._s.execute(stmt).all()
+
+        if not sims:
+            return
+
+        # fetch counts of resolved links for these simulations in one go
+        sim_ids = [sim.id for sim in sims]
+        counts_stmt = (
+            select(
+                store.simulation_links_table.c.source_id,
+                func.count().label("cnt"),
+            )
+            .where(store.simulation_links_table.c.source_id.in_(sim_ids))
+            .group_by(store.simulation_links_table.c.source_id)
+        )
+        resolved_counts = {
+            row.source_id: row.cnt for row in self._s.execute(counts_stmt).all()
+        }
+
+        # if needed, attempt to add links to the relational links table
+        for sim_id, coll_uid, sim_name, links_json in sims:
+            if not links_json:
+                continue
+
+            resolved_count = resolved_counts.get(sim_id, 0)
+
+            if resolved_count < len(links_json):
+                log.debug(f"Attempting to heal links for {coll_uid}:{sim_name}")
+                # re-run the update logic which is now idempotent
+                # We disable scan_and_sync to avoid expensive filesystem operations during healing
+                self.update_simulation_links(
+                    coll_uid, sim_name, links_json, scan_and_sync=False
+                )
 
     @RootProcessMeta.bcast_result
     @_sql_transaction

--- a/bamboost/index/base.py
+++ b/bamboost/index/base.py
@@ -743,89 +743,68 @@ class Index(metaclass=RootProcessMeta):
                 for collections and sync the target collection before trying again. This
                 can be helpful to find targets.
         """
-        scanned: bool = False  # flag to avoid multiple scans in case of multiple links
-        known_collection_uids: tuple[str, ...] = store.get_collection_uids(self._s)
+        sim_id, current_links = self._s.execute(
+            select(store.simulations_table.c.id, store.simulations_table.c.links).where(
+                store.simulations_table.c.collection_uid == collection_uid,
+                store.simulations_table.c.name == simulation_name,
+            )
+        ).first() or (None, None)
 
-        def _raise_or_log_invalid_target(target_uid: SimulationUID) -> None:
-            if raise_on_invalid_target:
+        if sim_id is None:
+            raise InvalidSimulationUIDError(
+                f"Simulation '{collection_uid}:{simulation_name}' does not exist in the index."
+            )
+
+        # normalize links to strings of SimulationUIDs
+        normalized_links = {k: str(SimulationUID(v)) for k, v in links.items()}
+
+        # update JSON Source of Truth (only if changed)
+        if normalized_links != current_links:
+            from sqlalchemy import update
+
+            self._s.execute(
+                update(store.simulations_table)
+                .where(store.simulations_table.c.id == sim_id)
+                .values(links=normalized_links)
+            )
+
+        # resolve and update relational links
+        link_payloads = []
+        scanned = False
+        known_collection_uids = store.get_collection_uids(self._s)
+
+        for ref_name, target_uid_str in normalized_links.items():
+            target_uid = SimulationUID(target_uid_str)
+            target_sim_id = store.fetch_simulation_id(
+                self._s, target_uid.collection_uid, target_uid.simulation_name
+            )
+
+            # if not found and discovery is enabled, try to find it
+            if target_sim_id is None and scan_and_sync:
+                if not scanned:
+                    colls = self.scan_for_collections()
+                    scanned = True
+                    known_collection_uids = tuple(coll[0] for coll in colls)
+
+                if target_uid.collection_uid in known_collection_uids:
+                    self.sync_collection(target_uid.collection_uid, heal_links=False)
+                    target_sim_id = store.fetch_simulation_id(
+                        self._s, target_uid.collection_uid, target_uid.simulation_name
+                    )
+
+            # handle result
+            if target_sim_id is not None:
+                link_payloads.append(
+                    {"source_id": sim_id, "target_id": target_sim_id, "name": ref_name}
+                )
+            elif raise_on_invalid_target:
                 raise InvalidSimulationUIDError(
-                    f"Target simulation '{target_uid}' cannot be found. "
-                    "This happened because strict link checking is enabled and all link targets "
-                    "are required to exist in the index. To skip invalid targets instead of "
-                    "raising an error, disable strict link checking in your configuration or "
-                    "invoke this operation with 'raise_on_invalid_target=False'."
+                    f"Target simulation '{target_uid}' cannot be found (strict mode)."
                 )
             else:
                 log.warning(f"Stale link. '{target_uid}' can not be found.")
 
-        def _find_target(target_uid: SimulationUID) -> int | None:
-            nonlocal scanned, known_collection_uids
-            target_sim_id = store.fetch_simulation_id(
-                self._s, target_uid.collection_uid, target_uid.simulation_name
-            )
-            if target_sim_id is not None:
-                return target_sim_id
-
-            if not scan_and_sync:
-                _raise_or_log_invalid_target(target_uid)
-                return None
-
-            log.debug(
-                f"Target simulation '{target_uid}' not found in cache. "
-                "Scanning for/syncing collections and trying again."
-            )
-            if not scanned:
-                colls = self.scan_for_collections()
-                scanned = True
-                known_collection_uids = tuple(coll[0] for coll in colls)
-
-            if target_uid.collection_uid not in known_collection_uids:
-                _raise_or_log_invalid_target(target_uid)
-                return None
-
-            self.sync_collection(target_uid.collection_uid, heal_links=False)
-            target_sim_id = store.fetch_simulation_id(
-                self._s, target_uid.collection_uid, target_uid.simulation_name
-            )
-            if target_sim_id is not None:
-                return target_sim_id
-
-            _raise_or_log_invalid_target(target_uid)
-            return None
-
-        sim_id = store.fetch_simulation_id(self._s, collection_uid, simulation_name)
-        if sim_id is None:
-            raise InvalidSimulationUIDError(
-                f"Simulation '{collection_uid}:{simulation_name}' does not exist in the index. "
-                "This happened because you are trying to update the links of a simulation that cannot be found."
-            )
-
-        # update the JSON column in the simulations table (Source of Truth)
-        # This ensures DataFrames and duplicate checks see all links.
-        from sqlalchemy import update
-
-        self._s.execute(
-            update(store.simulations_table)
-            .where(store.simulations_table.c.id == sim_id)
-            .values(links={k: str(SimulationUID(v)) for k, v in links.items()})
-        )
-
-        # update the relational table for resolved links
-        link_payloads = []
-
-        for ref_name, target_uid_or_string in links.items():
-            target_uid = SimulationUID(target_uid_or_string)
-            target_sim_id = _find_target(target_uid)
-            if target_sim_id is None:
-                # if the target simulation can not be found, we skip storing the link in
-                # the relational table for now.
-                continue
-
-            link_payloads.append(
-                {"source_id": sim_id, "target_id": target_sim_id, "name": ref_name}
-            )
-
-        # Remove existing relational links for this source before re-populating
+        # atomic update of the relational table
         self._s.execute(store.delete_simulation_links_stmt(sim_id))
         if link_payloads:
             self._s.execute(store.simulation_links_upsert_stmt(link_payloads))
@@ -864,9 +843,8 @@ class Index(metaclass=RootProcessMeta):
         """
         from sqlalchemy import func
 
-        # find all simulations where (count of resolved links) < (count of links in JSON)
-        # This is a bit tricky in pure SQL for JSON, so we'll just fetch simulations that
-        # HAVE links and do the check.
+        # identify simulations with potential stale links
+        # we fetch simulations that have links in the JSON source of truth.
         stmt = select(
             store.simulations_table.c.id,
             store.simulations_table.c.collection_uid,
@@ -880,11 +858,10 @@ class Index(metaclass=RootProcessMeta):
             )
 
         sims = self._s.execute(stmt).all()
-
         if not sims:
             return
 
-        # fetch counts of resolved links for these simulations in one go
+        # batch fetch currently resolved link counts
         sim_ids = [sim.id for sim in sims]
         counts_stmt = (
             select(
@@ -898,20 +875,18 @@ class Index(metaclass=RootProcessMeta):
             row.source_id: row.cnt for row in self._s.execute(counts_stmt).all()
         }
 
-        # if needed, attempt to add links to the relational links table
+        # if needed, resolve links for each simulation and update the relational table
         for sim_id, coll_uid, sim_name, links_json in sims:
-            if not links_json:
+            # skip if JSON is empty or already fully resolved in relational table
+            if not links_json or resolved_counts.get(sim_id, 0) >= len(links_json):
                 continue
 
-            resolved_count = resolved_counts.get(sim_id, 0)
-
-            if resolved_count < len(links_json):
-                log.debug(f"Attempting to heal links for {coll_uid}:{sim_name}")
-                # re-run the update logic which is now idempotent
-                # We disable scan_and_sync to avoid expensive filesystem operations during healing
-                self.update_simulation_links(
-                    coll_uid, sim_name, links_json, scan_and_sync=False
-                )
+            log.debug(f"Healing stale links for {coll_uid}:{sim_name}")
+            # update_simulation_links is idempotent and will reconcile the relational table.
+            # we disable scan_and_sync to keep this operation database-only.
+            self.update_simulation_links(
+                coll_uid, sim_name, links_json, scan_and_sync=False
+            )
 
     @RootProcessMeta.bcast_result
     @_sql_transaction

--- a/bamboost/index/store.py
+++ b/bamboost/index/store.py
@@ -30,7 +30,6 @@ from sqlalchemy.orm import Session
 from sqlalchemy.sql.dml import Delete, Insert, ReturningInsert
 from typing_extensions import Self
 
-from bamboost import constants
 from bamboost._logger import BAMBOOST_LOGGER
 from bamboost.constants import (
     TABLENAME_COLLECTIONS,
@@ -75,6 +74,7 @@ class LinkRecord:
     source_id: int
     target_id: int
     source_uid: SimulationUID
+    target_uid: SimulationUID
     name: str
 
     @classmethod
@@ -84,6 +84,7 @@ class LinkRecord:
             source_id=row["source_id"],
             target_id=row["target_id"],
             source_uid=SimulationUID(row["source_coll_uid"], row["source_name"]),
+            target_uid=SimulationUID(row["target_coll_uid"], row["target_name"]),
             name=row["name"],
         )
 
@@ -108,8 +109,11 @@ class SimulationRecord:
         cls,
         row: RowMapping,
         parameters: list[ParameterRecord],
-        links: dict[str, SimulationUID],
     ) -> SimulationRecord:
+        # pull links directly from the JSON column in the simulation row
+        raw_links = row.get("links") or {}
+        links = {k: SimulationUID(v) for k, v in raw_links.items()}
+
         return cls(
             id=row["id"],
             collection_uid=row["collection_uid"],
@@ -121,7 +125,7 @@ class SimulationRecord:
             status=row.get("status", ""),
             submitted=bool(row.get("submitted", False)),
             parameters=list(parameters or []),
-            links=links or {},
+            links=links,
         )
 
     @property
@@ -250,13 +254,11 @@ class CollectionRecord(CollectionMetadata):
         ]
         return unique, counts
 
-    def to_pandas(self, flatten: bool = True, include_links: bool = False) -> "DataFrame":
+    def to_pandas(self, flatten: bool = True, include_links: bool = True) -> DataFrame:
         import pandas as pd
 
         records = [
-            simulation.as_dict(
-                standalone=False, include_links=include_links or self.links is not None
-            )
+            simulation.as_dict(standalone=False, include_links=include_links)
             for simulation in self.simulations
         ]
         if flatten:
@@ -326,6 +328,7 @@ simulations_table = Table(
         server_default="initialized",
     ),
     Column("submitted", Boolean, nullable=False, default=False, server_default="0"),
+    Column("links", JSON, nullable=True),
     UniqueConstraint("collection_uid", "name", name="uix_collection_name"),
 )
 
@@ -514,10 +517,12 @@ def _fetch_parameters_for(
 def _fetch_links_for(
     session: Session, simulation_ids: Sequence[int]
 ) -> dict[int, dict[str, SimulationUID]]:
+    # this method is now ONLY for discovering valid relational targets
+    # if needed. SimulationRecord.from_mapping now pulls links from
+    # the JSON column.
     if not simulation_ids:
         return {}
 
-    # We join with simulations_table to get the target UID (collection_uid:name)
     stmt = (
         select(
             simulation_links_table.c.source_id,
@@ -536,12 +541,10 @@ def _fetch_links_for(
     rows = session.execute(stmt).mappings().all()
 
     result: dict[int, dict[str, SimulationUID]] = {}
-
     for row in rows:
         source_id = row["source_id"]
-        link_name = row["link_name"]
         target_uid = SimulationUID(row["collection_uid"], row["target_name"])
-        result.setdefault(source_id, {})[link_name] = target_uid
+        result.setdefault(source_id, {})[row["link_name"]] = target_uid
     return result
 
 
@@ -778,10 +781,7 @@ def fetch_simulation(
     if row is None:
         return None
     parameters_map = _fetch_parameters_for(session, [row["id"]])
-    links_map = _fetch_links_for(session, [row["id"]])
-    return SimulationRecord.from_mapping(
-        row, parameters_map.get(row["id"], []), links_map.get(row["id"], {})
-    )
+    return SimulationRecord.from_mapping(row, parameters_map.get(row["id"], []))
 
 
 def fetch_simulations_by_uid(
@@ -797,11 +797,8 @@ def fetch_simulations_by_uid(
     rows = session.execute(stmt).mappings().all()
     simulation_ids = [row["id"] for row in rows]
     parameters_map = _fetch_parameters_for(session, simulation_ids)
-    links_map = _fetch_links_for(session, simulation_ids)
     return [
-        SimulationRecord.from_mapping(
-            row, parameters_map.get(row["id"], []), links_map.get(row["id"], {})
-        )
+        SimulationRecord.from_mapping(row, parameters_map.get(row["id"], []))
         for row in rows
     ]
 
@@ -819,11 +816,8 @@ def fetch_simulations(
     rows = session.execute(stmt).mappings().all()
     simulation_ids = [row["id"] for row in rows]
     parameters_map = _fetch_parameters_for(session, simulation_ids)
-    links_map = _fetch_links_for(session, simulation_ids)
     return [
-        SimulationRecord.from_mapping(
-            row, parameters_map.get(row["id"], []), links_map.get(row["id"], {})
-        )
+        SimulationRecord.from_mapping(row, parameters_map.get(row["id"], []))
         for row in rows
     ]
 
@@ -834,53 +828,49 @@ def fetch_parameters(session: Session) -> list[ParameterRecord]:
 
 
 def fetch_links(session: Session) -> list[LinkRecord]:
-    rows = (
-        session.execute(
-            select(
-                simulation_links_table,
-                simulations_table.c.collection_uid.label("source_coll_uid"),
-                simulations_table.c.name.label("source_name"),
-            ).join(
-                simulations_table,
-                simulation_links_table.c.source_id == simulations_table.c.id,
-            )
-        )
-        .mappings()
-        .all()
-    )
-    return [LinkRecord.from_mapping(row) for row in rows]
-
-
-def fetch_collection_links(session: Session, collection_uid: str) -> list[LinkRecord]:
-    """Fetch all links for a collection."""
-    stmt = (
-        select(
-            simulation_links_table,
-            simulations_table.c.collection_uid.label("source_coll_uid"),
-            simulations_table.c.name.label("source_name"),
-        )
-        .join(
-            simulations_table,
-            simulation_links_table.c.source_id == simulations_table.c.id,
-        )
-        .where(simulations_table.c.collection_uid == collection_uid)
-    )
-    rows = session.execute(stmt).mappings().all()
-    return [LinkRecord.from_mapping(row) for row in rows]
-
-
-def fetch_collection_links_map(
-    session: Session, collection_uid: str
-) -> dict[str, dict[str, str]]:
-    """Fetch all links for a collection as a mapping from simulation name to links."""
+    """Fetch all links in the database. These are only resolved (valid) links."""
     sim_src = simulations_table.alias("sim_src")
     sim_target = simulations_table.alias("sim_target")
 
     stmt = (
         select(
+            simulation_links_table.c.id,
+            simulation_links_table.c.source_id,
+            simulation_links_table.c.target_id,
+            simulation_links_table.c.name,
+            sim_src.c.collection_uid.label("source_coll_uid"),
             sim_src.c.name.label("source_name"),
-            simulation_links_table.c.name.label("link_name"),
-            sim_target.c.collection_uid.label("target_collection_uid"),
+            sim_target.c.collection_uid.label("target_coll_uid"),
+            sim_target.c.name.label("target_name"),
+        )
+        .select_from(
+            simulation_links_table.join(
+                sim_src,
+                simulation_links_table.c.source_id == sim_src.c.id,
+            ).join(
+                sim_target,
+                simulation_links_table.c.target_id == sim_target.c.id,
+            )
+        )
+    )
+    rows = session.execute(stmt).mappings().all()
+    return [LinkRecord.from_mapping(row) for row in rows]
+
+
+def fetch_collection_links(session: Session, collection_uid: str) -> list[LinkRecord]:
+    """Fetch all links for a collection. Valid links only."""
+    sim_src = simulations_table.alias("sim_src")
+    sim_target = simulations_table.alias("sim_target")
+
+    stmt = (
+        select(
+            simulation_links_table.c.id,
+            simulation_links_table.c.source_id,
+            simulation_links_table.c.target_id,
+            simulation_links_table.c.name,
+            sim_src.c.collection_uid.label("source_coll_uid"),
+            sim_src.c.name.label("source_name"),
+            sim_target.c.collection_uid.label("target_coll_uid"),
             sim_target.c.name.label("target_name"),
         )
         .select_from(
@@ -894,14 +884,22 @@ def fetch_collection_links_map(
         )
         .where(sim_src.c.collection_uid == collection_uid)
     )
-
     rows = session.execute(stmt).mappings().all()
-    result: dict[str, dict[str, str]] = {}
-    for row in rows:
-        source_name = row["source_name"]
-        link_name = row["link_name"]
-        target_uid = f"{row['target_collection_uid']}{constants.UID_SEPARATOR}{row['target_name']}"
-        result.setdefault(source_name, {})[link_name] = target_uid
+    return [LinkRecord.from_mapping(row) for row in rows]
+
+
+def fetch_collection_links_map(
+    session: Session, collection_uid: str
+) -> dict[str, dict[str, SimulationUID]]:
+    """Fetch all links for a collection as a mapping from simulation name to links."""
+    stmt = select(simulations_table.c.name, simulations_table.c.links).where(
+        simulations_table.c.collection_uid == collection_uid
+    )
+    rows = session.execute(stmt).all()
+    result = {}
+    for name, raw_links in rows:
+        if raw_links:
+            result[name] = {k: SimulationUID(v) for k, v in raw_links.items()}
     return result
 
 

--- a/bamboost/index/store.py
+++ b/bamboost/index/store.py
@@ -250,11 +250,13 @@ class CollectionRecord(CollectionMetadata):
         ]
         return unique, counts
 
-    def to_pandas(self, flatten: bool = True) -> "DataFrame":
+    def to_pandas(self, flatten: bool = True, include_links: bool = False) -> "DataFrame":
         import pandas as pd
 
         records = [
-            simulation.as_dict(standalone=False, include_links=False)
+            simulation.as_dict(
+                standalone=False, include_links=include_links or self.links is not None
+            )
             for simulation in self.simulations
         ]
         if flatten:

--- a/tests/core/test_collection.py
+++ b/tests/core/test_collection.py
@@ -317,3 +317,63 @@ def test_collection_by_path_not_in_db(tmp_path: Path):
     assert collection.uid == testuid
     # assert uid is now in index
     assert collection.uid in map(lambda i: i.uid, collection._index.all_collections)
+
+
+def test_add_duplicate_action_skip(tmp_collection_burn: Collection):
+    params = {"a": 1, "b": 2}
+    sim1 = tmp_collection_burn.add("sim1", parameters=params)
+
+    # Try to add again with skip
+    sim2 = tmp_collection_burn.add("sim2", parameters=params, duplicate_action="skip")
+
+    assert sim2.name == "sim1"
+    assert len(tmp_collection_burn) == 1
+
+
+def test_add_duplicate_action_ignore(tmp_collection_burn: Collection):
+    params = {"a": 1, "b": 2}
+    tmp_collection_burn.add("sim1", parameters=params)
+
+    # Try to add again with ignore
+    tmp_collection_burn.add("sim2", parameters=params, duplicate_action="ignore")
+
+    assert len(tmp_collection_burn) == 2
+    assert set(tmp_collection_burn.all_simulation_names()) == {"sim1", "sim2"}
+
+
+def test_add_duplicate_action_replace_exact(tmp_collection_burn: Collection):
+    params = {"a": 1, "b": 2}
+    tmp_collection_burn.add("sim1", parameters=params)
+
+    # Try to add again with replace (exact match)
+    tmp_collection_burn.add("sim2", parameters=params, duplicate_action="replace")
+
+    assert len(tmp_collection_burn) == 1
+    assert tmp_collection_burn.all_simulation_names() == ["sim2"]
+
+
+def test_add_duplicate_action_replace_partial_no_match(tmp_collection_burn: Collection):
+    tmp_collection_burn.add("sim1", parameters={"a": 1, "b": 2})
+    tmp_collection_burn.add("sim2", parameters={"a": 1, "b": 3})
+
+    # Try to add with only {"a": 1}. Should NOT match sim1 or sim2 because it's not an exact match.
+    tmp_collection_burn.add("sim3", parameters={"a": 1}, duplicate_action="replace")
+
+    assert len(tmp_collection_burn) == 3
+    assert set(tmp_collection_burn.all_simulation_names()) == {"sim1", "sim2", "sim3"}
+
+
+def test_add_duplicate_action_replace_filtered_collection(
+    tmp_collection_burn: Collection,
+):
+    tmp_collection_burn.add("sim1", parameters={"a": 1, "b": 2})
+
+    # Filter so sim1 is not visible
+    filtered = tmp_collection_burn.filter(tmp_collection_burn.k["a"] == 100)
+    assert len(filtered) == 0
+
+    # Adding an exact match to sim1 via the filtered collection should still work and replace sim1
+    filtered.add("sim2", parameters={"a": 1, "b": 2}, duplicate_action="replace")
+
+    assert len(tmp_collection_burn) == 1
+    assert tmp_collection_burn.all_simulation_names() == ["sim2"]

--- a/tests/core/test_collection.py
+++ b/tests/core/test_collection.py
@@ -377,3 +377,32 @@ def test_add_duplicate_action_replace_filtered_collection(
 
     assert len(tmp_collection_burn) == 1
     assert tmp_collection_burn.all_simulation_names() == ["sim2"]
+
+
+def test_add_duplicate_action_replace_with_links(tmp_collection_burn: Collection):
+    other1 = tmp_collection_burn.add("other1", parameters={"x": 1})
+    other2 = tmp_collection_burn.add("other2", parameters={"x": 2})
+
+    params = {"a": 1}
+    tmp_collection_burn.add(
+        "sim1", parameters=params, links={"ref": other1.uid}, override=True
+    )
+
+    # Try to add again with same params but DIFFERENT link.
+    # Should NOT be a duplicate.
+    tmp_collection_burn.add(
+        "sim2", parameters=params, links={"ref": other2.uid}, duplicate_action="replace"
+    )
+
+    assert len(tmp_collection_burn) == 4  # other1, other2, sim1, sim2
+    assert "sim1" in tmp_collection_burn.all_simulation_names()
+    assert "sim2" in tmp_collection_burn.all_simulation_names()
+
+    # Try to add again with SAME params and SAME link.
+    # Should be a duplicate and replace sim2.
+    tmp_collection_burn.add(
+        "sim3", parameters=params, links={"ref": other2.uid}, duplicate_action="replace"
+    )
+
+    assert "sim2" not in tmp_collection_burn.all_simulation_names()
+    assert "sim3" in tmp_collection_burn.all_simulation_names()

--- a/tests/core/test_parameter_validation.py
+++ b/tests/core/test_parameter_validation.py
@@ -1,0 +1,44 @@
+import pytest
+
+from bamboost import Collection
+
+
+def test_parameter_key_validation_reserved_add(tmp_collection_burn: Collection):
+    # 'name' is a reserved key
+    with pytest.raises(ValueError, match="is reserved"):
+        tmp_collection_burn.add(parameters={"name": "invalid"})
+
+
+def test_parameter_key_validation_period_add(tmp_collection_burn: Collection):
+    # periods are not allowed in keys
+    with pytest.raises(ValueError, match="cannot contain a period"):
+        tmp_collection_burn.add(parameters={"invalid.key": 1})
+
+
+def test_parameter_key_validation_reserved_update(tmp_collection_burn: Collection):
+    sim = tmp_collection_burn.add("sim1", parameters={"a": 1})
+    with sim.edit() as sw:
+        with pytest.raises(ValueError, match="is reserved"):
+            sw.parameters["status"] = "finished"
+
+        with pytest.raises(ValueError, match="is reserved"):
+            sw.parameters.update({"tags": ["a"]})
+
+
+def test_parameter_key_validation_period_update(tmp_collection_burn: Collection):
+    sim = tmp_collection_burn.add("sim1", parameters={"a": 1})
+    with sim.edit() as sw:
+        # Note: sw.parameters["b.c"] = 1 is actually supported by the code
+        # (it creates a nested dict), but the request said keys should NEVER
+        # contain a period.
+        # Actually, Parameters.__setitem__ validates the key BEFORE splitting it.
+        with pytest.raises(ValueError, match="cannot contain a period"):
+            sw.parameters["b.c"] = 1
+
+        with pytest.raises(ValueError, match="cannot contain a period"):
+            sw.parameters.update({"x.y": 2})
+
+
+def test_parameter_key_validation_links_reserved(tmp_collection_burn: Collection):
+    with pytest.raises(ValueError, match="is reserved"):
+        tmp_collection_burn.add(parameters={"links": "something"})

--- a/tests/index/test_index_simulations.py
+++ b/tests/index/test_index_simulations.py
@@ -221,7 +221,11 @@ def test_collection_links(index_with_collection: Tuple[Index, Path]):
     )
 
     coll = index.collection("COLL001")
-    assert coll.links == {"sim1": {"l1": "COLL001:T1"}, "sim2": {"l2": "COLL001:T2"}}
+    expected_links = {
+        "sim1": {"l1": SimulationUID("COLL001:T1")},
+        "sim2": {"l2": SimulationUID("COLL001:T2")},
+    }
+    assert coll.links == expected_links
 
     # Test new efficient links queries
     links = index.collection_links("COLL001")
@@ -229,10 +233,95 @@ def test_collection_links(index_with_collection: Tuple[Index, Path]):
     assert {l.name for l in links} == {"l1", "l2"}
 
     links_map = index.collection_links_map("COLL001")
-    assert links_map == {"sim1": {"l1": "COLL001:T1"}, "sim2": {"l2": "COLL001:T2"}}
+    assert links_map == expected_links
 
     # Test backlinks
     backlinks = index.backlinks("COLL001:T1")
     assert len(backlinks) == 1
     assert backlinks[0][0] == SimulationUID("COLL001", "sim1")
     assert backlinks[0][1] == "l1"
+
+
+def test_stale_link_storage_and_healing(index_with_collection: Tuple[Index, Path]):
+    index, collection_path = index_with_collection
+    index.search_paths.add(collection_path.parent)
+
+    # Create identifier file so find_collection works
+    from bamboost.index import create_identifier_file
+    create_identifier_file(collection_path, "COLL001")
+
+    # Create dummy simulation file
+    import h5py
+    sim1_path = collection_path / "sim1"
+    sim1_path.mkdir()
+    with h5py.File(sim1_path / "data.h5", "w") as f:
+        f.create_group(".parameters")
+        f.create_group(".links")
+
+    # Create sim1 with a link to a non-existent sim2
+    links = {"ref1": "COLL001:sim2"}
+    with index.sql_transaction():
+        index.upsert_simulation(
+            collection_uid="COLL001",
+            simulation_name="sim1",
+            metadata={},
+            parameters={},
+            links=links,
+            collection_path=collection_path,
+        )
+
+    # Verify link is stored as stale (SimulationUID is present in JSON but NOT in relational table)
+    sim1 = index.simulation(SimulationUID("COLL001", "sim1"))
+    assert sim1 is not None
+    assert sim1.links == {"ref1": SimulationUID("COLL001", "sim2")}
+
+    # Check database directly
+    from sqlalchemy import select
+    from bamboost.index import store
+
+    with index.sql_transaction():
+        # 1. Should be in JSON column
+        row = index._s.execute(
+            select(store.simulations_table).where(
+                store.simulations_table.c.name == "sim1"
+            )
+        ).mappings().first()
+        assert row["links"] == {"ref1": "COLL001:sim2"}
+
+        # 2. Should NOT be in relational table yet (target not found)
+        rel_row = index._s.execute(
+            select(store.simulation_links_table).where(
+                store.simulation_links_table.c.name == "ref1"
+            )
+        ).mappings().first()
+        assert rel_row is None
+
+    # Now add the target sim2
+    sim2_path = collection_path / "sim2"
+    sim2_path.mkdir()
+    with h5py.File(sim2_path / "data.h5", "w") as f:
+        f.create_group(".parameters")
+        f.create_group(".links")
+
+    with index.sql_transaction():
+        index.upsert_simulation(
+            "COLL001",
+            "sim2",
+            metadata={},
+            parameters={},
+            links={},
+            collection_path=collection_path,
+        )
+
+    # Healing should happen during sync
+    index.sync_collection("COLL001")
+
+    # Verify target_id is now populated in relational table
+    with index.sql_transaction():
+        row = index._s.execute(
+            select(store.simulation_links_table).where(
+                store.simulation_links_table.c.name == "ref1"
+            )
+        ).mappings().first()
+        assert row is not None
+        assert row["target_id"] is not None


### PR DESCRIPTION
Fixes serious bug: the duplicate check would flag simulations as duplicates if all GIVEN parameters match. It should do exact matching, i.e. if existing sims have additional params, then they are NOT duplicates.

Furthermore: links should be checked too, because simulations that reference different other ones (e.g. meshes) are different!

---

Changes (Backwards Compatible):
 * Collection.to_pandas now includes an include_links argument (defaults to True).
 * Index.sync_collection now has an optional heal_links argument (defaults to True).
 * Collection._list_duplicates and _check_duplicate have been updated to support link-based duplicate checking.
 * Index.collection_links_map now returns a dictionary of SimulationUID objects instead of strings.

Database Schema Changes:
 * A new links (JSON) column has been added to the simulations_table. This column serves as the "source of
   truth" for simulation links and is essential for the new stale-link healing mechanism.

Behaviour Changes:
 * Duplicate checking now includes links by default.
 * Parameter keys are now validated (no periods, no reserved names).
 * SimulationRecord.from_mapping now fetches links from the JSON column rather than the relational table.
 * The Index now includes a heal_stale_links method for reconciling missing relational link records.