### PR TITLE
Enh/no wait on lock on sync

### DIFF
--- a/bamboost/core/hdf5/file.py
+++ b/bamboost/core/hdf5/file.py
@@ -304,6 +304,7 @@ class HDF5File(h5py.File, Generic[_MT]):
     file_map: FileMap
     _is_open_on_root_only: bool = False
     _attrs_dict_instances: dict[str, "AttrsDict[_MT]"] = {}
+    wait_on_lock = True
 
     @overload
     def __init__(
@@ -437,6 +438,8 @@ class HDF5File(h5py.File, Generic[_MT]):
 
                 return self
             except BlockingIOError:
+                if not self.wait_on_lock: 
+                    raise
                 # If the file is locked, we wait and try again
                 if not waiting_logged:
                     level = logging._nameToLevel[config.options.log_file_lock_severity]
@@ -445,6 +448,7 @@ class HDF5File(h5py.File, Generic[_MT]):
                     )
                 waiting_logged = True
                 time.sleep(0.01)
+
 
     def close(self):
         self._context_stack = max(0, self._context_stack - 1)

--- a/bamboost/core/hdf5/file.py
+++ b/bamboost/core/hdf5/file.py
@@ -433,8 +433,8 @@ class HDF5File(h5py.File, Generic[_MT]):
                 )
 
                 # create file map
-                if not self.file_map.valid:
-                    self.file_map.populate()
+                # if not self.file_map.valid:
+                    # self.file_map.populate()
 
                 return self
             except BlockingIOError:

--- a/bamboost/index/base.py
+++ b/bamboost/index/base.py
@@ -417,9 +417,13 @@ class Index(metaclass=RootProcessMeta):
 
         for name in all_simulations_fs:
             log.debug(f"Syncing simulation {name} in collection {uid}.")
-            self.upsert_simulation(
-                collection_uid=uid, simulation_name=name, collection_path=path
-            )
+            try:
+                self.upsert_simulation(
+                    collection_uid=uid, simulation_name=name, collection_path=path
+                )
+            except BlockingIOError as exc:
+                log.info(f"Couldn't open hdf for {name} in collection {uid}: {exc}")
+                continue
 
     @property
     @RootProcessMeta.bcast_result
@@ -652,6 +656,7 @@ class Index(metaclass=RootProcessMeta):
                 index=self,
                 collection_uid=collection_uid,
             )
+            sim._file.wait_on_lock = False
             with sim._file.open("r"):
                 metadata, parameters, links = (
                     sim.metadata._dict,


### PR DESCRIPTION
TODO items: 
- [ ] allow to configure whether a hdf5 file wil populate the file map on open or not, depending on the use case. 


File map population can be slow and must be avoided when syncing collections