### PR TITLE
Bug/none kills duplicates

### DIFF
--- a/bamboost/core/collection.py
+++ b/bamboost/core/collection.py
@@ -838,8 +838,13 @@ class Collection(ElligibleForPlugin):
         if s.empty:
             mask = pd.Series(True, index=df.index)
         else:
-            # Vectorized comparison (handles ComparableIterable via __eq__ and object-dtype columns)
-            mask = (df[s.keys()] == s).all(axis=1)
+            # Treat missing values as equal when both sides are missing.
+            # Pandas compares None/NaN as unequal with `==`, so combine equality
+            # with a per-cell both-missing condition.
+            subset = df[s.keys()]
+            eq = subset.eq(s)
+            both_missing = subset.isna() & s.isna()
+            mask = (eq | both_missing).all(axis=1)
 
         if exact:
             # For exact match, all other parameter/link columns must be NaN/missing.

--- a/tests/core/test_collection.py
+++ b/tests/core/test_collection.py
@@ -399,6 +399,30 @@ def test_add_duplicate_action_replace_exact_with_none(tmp_collection_burn: Colle
     assert tmp_collection_burn.all_simulation_names() == ["sim2"]
 
 
+def test_add_duplicate_action_works_with_none1(tmp_collection_burn: Collection):
+    params = {"thermostat": None, "a": 1}
+    tmp_collection_burn.add("sim1", parameters=params)
+    params = {"thermostat": None, "a": 2}
+
+    # None should be treated as equal missing value for duplicate detection.
+    tmp_collection_burn.add("sim2", parameters=params, duplicate_action="replace")
+
+    assert len(tmp_collection_burn) == 2
+    assert tmp_collection_burn.all_simulation_names() == ["sim1", "sim2"]
+
+
+def test_add_duplicate_action_works_with_none2(tmp_collection_burn: Collection):
+    params = {"thermostat": None, "a": 1}
+    tmp_collection_burn.add("sim1", parameters=params)
+    params = {"thermostat": 2, "a": 1}
+
+    # None should be treated as equal missing value for duplicate detection.
+    tmp_collection_burn.add("sim2", parameters=params, duplicate_action="replace")
+
+    assert len(tmp_collection_burn) == 2
+    assert tmp_collection_burn.all_simulation_names() == ["sim1", "sim2"]
+
+
 def test_add_duplicate_action_replace_partial_no_match(tmp_collection_burn: Collection):
     tmp_collection_burn.add("sim1", parameters={"a": 1, "b": 2})
     tmp_collection_burn.add("sim2", parameters={"a": 1, "b": 3})

--- a/tests/core/test_collection.py
+++ b/tests/core/test_collection.py
@@ -388,6 +388,17 @@ def test_add_duplicate_action_replace_exact(tmp_collection_burn: Collection):
     assert tmp_collection_burn.all_simulation_names() == ["sim2"]
 
 
+def test_add_duplicate_action_replace_exact_with_none(tmp_collection_burn: Collection):
+    params = {"thermostat": None, "a": 1}
+    tmp_collection_burn.add("sim1", parameters=params)
+
+    # None should be treated as equal missing value for duplicate detection.
+    tmp_collection_burn.add("sim2", parameters=params, duplicate_action="replace")
+
+    assert len(tmp_collection_burn) == 1
+    assert tmp_collection_burn.all_simulation_names() == ["sim2"]
+
+
 def test_add_duplicate_action_replace_partial_no_match(tmp_collection_burn: Collection):
     tmp_collection_burn.add("sim1", parameters={"a": 1, "b": 2})
     tmp_collection_burn.add("sim2", parameters={"a": 1, "b": 3})


### PR DESCRIPTION
BUG: If a parameter value is None duplicate check will never match. 

This PR fixes that 