### PR TITLE
Add config option `file_lock_timeout` to fail if lock can not be aquired

### DIFF
--- a/bamboost/_config.py
+++ b/bamboost/_config.py
@@ -340,7 +340,8 @@ class _Options(_Base):
 
     file_lock_timeout: float | None = field(default=60.0)
     """The timeout in seconds to wait for acquiring a file lock.
-    Set to None or 0 to wait indefinitely."""
+    Set to 0 to disable waiting at all, and to None or a negative value to wait
+    indefinitely."""
 
     log_root_only: bool = False
     """If True, only the root logger is used."""

--- a/bamboost/_config.py
+++ b/bamboost/_config.py
@@ -338,6 +338,10 @@ class _Options(_Base):
     )
     """The severity level for the log file lock."""
 
+    file_lock_timeout: float | None = field(default=60.0)
+    """The timeout in seconds to wait for acquiring a file lock.
+    Set to None or 0 to wait indefinitely."""
+
     log_root_only: bool = False
     """If True, only the root logger is used."""
 

--- a/bamboost/core/hdf5/file.py
+++ b/bamboost/core/hdf5/file.py
@@ -420,7 +420,6 @@ class HDF5File(h5py.File, Generic[_MT]):
     def _try_open_repeat(
         self, mode: FileMode, driver: Optional[Literal["mpio"]] = None
     ) -> Self:
-        waiting_logged = False
         kwargs: dict[str, Any] = {}
         if driver == "mpio":
             # check for comm.size > 1 to avoid using mpio if comm is our serial mock comm
@@ -428,6 +427,12 @@ class HDF5File(h5py.File, Generic[_MT]):
                 kwargs.update({"driver": driver, "comm": self._comm})
         else:
             kwargs.update({"driver": driver} if driver not in (None, "mpio") else {})
+
+        waiting_logged = False
+        timeout = config.options.file_lock_timeout
+        start_time = time.monotonic()
+        last_logged = start_time
+        sleep_interval = 0.01
 
         # try to open the file until it is available
         while True:
@@ -438,13 +443,34 @@ class HDF5File(h5py.File, Generic[_MT]):
                 )
 
                 return self
-            except BlockingIOError:
+            except BlockingIOError as e:
+                now = time.monotonic()
+                elapsed = now - start_time
+
+                # Check if we exceeded the configured timeout
+                if timeout is not None and timeout > 0 and elapsed >= timeout:
+                    log.error(
+                        f"[{self._filename}] Timeout after {elapsed:.1f}s waiting for file lock"
+                    )
+                    raise TimeoutError(
+                        f"Timeout of {timeout}s exceeded while waiting to acquire lock "
+                        f"on HDF5 file '{self._filename}'."
+                    ) from e
+
                 # If the file is locked, we wait and try again
                 if not waiting_logged:
                     level = logging._nameToLevel[config.options.log_file_lock_severity]
                     log.log(level, f"[{self._filename}] file locked --> waiting")
-                waiting_logged = True
-                time.sleep(0.01)
+                    waiting_logged = True
+                    last_logged = now
+                elif now - last_logged >= 10.0:
+                    log.warning(
+                        f"[{self._filename}] still waiting for file lock (elapsed: {elapsed:.1f}s)..."
+                    )
+                    last_logged = now
+
+                time.sleep(sleep_interval)
+                sleep_interval = min(sleep_interval * 2, 1.0)
 
     _is_applying_queue: bool = False
 

--- a/bamboost/core/hdf5/file.py
+++ b/bamboost/core/hdf5/file.py
@@ -358,23 +358,31 @@ class HDF5File(h5py.File, Generic[_MT]):
         self: HDF5File[Immutable],
         mode: Literal[FileMode.READ, "r"] = "r",
         driver: Optional[Literal["mpio"]] = None,
+        *,
+        timeout: float | None = None,
     ) -> HDF5File[Immutable]: ...
     @overload
     def open(
         self: HDF5File[Mutable],
         mode: Union[FileMode, Literal["r", "r+", "w", "w-", "x", "a"]] = "r",
         driver: Optional[Literal["mpio"]] = None,
+        *,
+        timeout: float | None = None,
     ) -> HDF5File[Mutable]: ...
     @overload
     def open(
         self: HDF5File,
         mode: Union[FileMode, str] = "r",
         driver: Optional[Literal["mpio"]] = None,
+        *,
+        timeout: float | None = None,
     ) -> HDF5File: ...
     def open(
         self,
         mode: Union[FileMode, str] = "r",
         driver=None,
+        *,
+        timeout: float | None = None,
     ) -> HDF5File:
         """Context manager to opens the HDF5 file with the specified mode and
         driver.
@@ -386,6 +394,8 @@ class HDF5File(h5py.File, Generic[_MT]):
             mode: The mode to open the file with. Defaults to "r" (read-only).
             driver: The driver to use for file I/O. If "mpio" and MPI is
                 active, it will use MPI I/O. Defaults to None.
+            timeout: Optional timeout in seconds to wait for the file lock. If None, use
+                default from config.
 
         Returns:
             HDF5File: The opened HDF5 file object.
@@ -415,10 +425,14 @@ class HDF5File(h5py.File, Generic[_MT]):
                 # just increase the context stack and return
                 return self
 
-        return self._try_open_repeat(mode, driver)
+        return self._try_open_repeat(mode, driver, timeout=timeout)
 
     def _try_open_repeat(
-        self, mode: FileMode, driver: Optional[Literal["mpio"]] = None
+        self,
+        mode: FileMode,
+        driver: Optional[Literal["mpio"]] = None,
+        *,
+        timeout: float | None = None,
     ) -> Self:
         kwargs: dict[str, Any] = {}
         if driver == "mpio":
@@ -428,8 +442,10 @@ class HDF5File(h5py.File, Generic[_MT]):
         else:
             kwargs.update({"driver": driver} if driver not in (None, "mpio") else {})
 
+        if timeout is None:
+            timeout = config.options.file_lock_timeout
+
         waiting_logged = False
-        timeout = config.options.file_lock_timeout
         start_time = time.monotonic()
         last_logged = start_time
         sleep_interval = 0.01
@@ -444,6 +460,14 @@ class HDF5File(h5py.File, Generic[_MT]):
 
                 return self
             except BlockingIOError as e:
+                if timeout == 0:
+                    log.error(
+                        f"[{self._filename}] File is locked and timeout is set to 0, not retrying."
+                    )
+                    raise TimeoutError(
+                        "File is locked and timeout is set to 0, not retrying."
+                    ) from e
+
                 now = time.monotonic()
                 elapsed = now - start_time
 

--- a/bamboost/index/base.py
+++ b/bamboost/index/base.py
@@ -457,9 +457,19 @@ class Index(metaclass=RootProcessMeta):
 
         for name in all_simulations_fs:
             log.debug(f"Syncing simulation {name} in collection {uid}.")
-            self.upsert_simulation(
-                collection_uid=uid, simulation_name=name, collection_path=path
-            )
+            try:
+                self.upsert_simulation(
+                    collection_uid=uid,
+                    simulation_name=name,
+                    collection_path=path,
+                    timeout=0.1,
+                )
+            except TimeoutError as e:
+                # if we timeout while trying to read the HDF5 file, we skip the simulation and
+                # continue with the next one. This can happen if another process is currently writing
+                log.warning(
+                    f"Timeout while syncing simulation {name} in collection {uid}: {e}"
+                )
 
         if heal_links:
             self.heal_stale_links(uid)
@@ -663,6 +673,7 @@ class Index(metaclass=RootProcessMeta):
         links: Mapping[Any, Any] | None = None,
         *,
         collection_path: StrPath | None = None,
+        timeout: float | None = None,
     ) -> None:
         """Cache a simulation from a collection.
 
@@ -688,7 +699,7 @@ class Index(metaclass=RootProcessMeta):
                 comm=self._comm,
                 collection_uid=collection_uid,
             )
-            with sim._file.open("r"):
+            with sim._file.open("r", timeout=timeout):
                 metadata, parameters, links = (
                     sim.metadata._dict,
                     sim.parameters._dict,

--- a/tests/core/test_hdf_file.py
+++ b/tests/core/test_hdf_file.py
@@ -305,3 +305,9 @@ def test_hdf5_file_lock_timeout(hdf5_file: HDF5File):
                 hdf5_file.open("w")
             assert "Timeout" in str(exc_info.value)
 
+
+def test_hdf5_file_lock_timeout_zero(hdf5_file: HDF5File):
+    with patch("h5py.File.__init__", side_effect=BlockingIOError):
+        with pytest.raises(TimeoutError) as exc_info:
+            hdf5_file.open("w", timeout=0)
+        assert "not retrying" in str(exc_info.value)

--- a/tests/core/test_hdf_file.py
+++ b/tests/core/test_hdf_file.py
@@ -294,3 +294,14 @@ def test_hdf5_file_force_close(hdf5_file: HDF5File):
     hdf5_file.open("w")
     hdf5_file.force_close()
     assert not hdf5_file.is_open
+
+
+def test_hdf5_file_lock_timeout(hdf5_file: HDF5File):
+    from bamboost._config import config
+
+    with patch("h5py.File.__init__", side_effect=BlockingIOError):
+        with patch.object(config.options, "file_lock_timeout", 0.05):
+            with pytest.raises(TimeoutError) as exc_info:
+                hdf5_file.open("w")
+            assert "Timeout" in str(exc_info.value)
+


### PR DESCRIPTION
Replaces #25 

Currently, if a file is locked, we retry forever. This introduces a timeout and transparently raises a `TimeOutError` if the ellapsed time exceeds the set timeout.